### PR TITLE
Atualização do boleto caixa

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -420,6 +420,16 @@ namespace BoletoNet
                 //Limpa as intruções para o Cedente
                 _instrucoesHtml = "";
 
+		//Suelton - 12/03/2018
+                //Para homologação da Caixa é obrigatório ter as informações do SAC
+                if (Banco.Codigo == 104)
+                {
+                    //_instrucoesHtml = _instrucoesHtml +
+                    //                  "<br><br><p>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)</p> <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 </p><p> Ouvidoria: 0800 725 7474 - caixa.gov.br </p>";
+                    _instrucoesHtml = _instrucoesHtml +
+                                      "<br>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)<br/> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 Ouvidoria: 0800 725 7474 <br/> caixa.gov.br";
+                }
+		
                 MontaInstrucoes(Boleto.Instrucoes);
 
                 if (Boleto.Cedente.Instrucoes.Count > 0)
@@ -470,20 +480,8 @@ namespace BoletoNet
                     //Adiciona a instrução as instruções disponíveis no Boleto
                     Instrucoes.Add(instrucao);
                 }
-
-                //Suelton - 12/03/2018
-                //Para homologação da Caixa é obrigatório ter as informações do SAC
-                if (Banco.Codigo == 104)
-                {
-                    //_instrucoesHtml = _instrucoesHtml +
-                    //                  "<br><br><p>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)</p> <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 </p><p> Ouvidoria: 0800 725 7474 - caixa.gov.br </p>";
-                    _instrucoesHtml = _instrucoesHtml +
-                                      "<br>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)<br/> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 Ouvidoria: 0800 725 7474 <br/> caixa.gov.br";
-                }
-                else
-                {
-                    _instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
-                }
+		
+		_instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
             }
         }
 

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -362,6 +362,8 @@ namespace BoletoNet
                 //Limpa as intruções para o Sacado
                 _instrucoesHtml = "";
 
+                MontaInstrucaoCaixa();
+
                 MontaInstrucoes(Boleto.Instrucoes);
 
                 if (Boleto.Sacado.Instrucoes.Count > 0)
@@ -420,16 +422,8 @@ namespace BoletoNet
                 //Limpa as intruções para o Cedente
                 _instrucoesHtml = "";
 
-		//Suelton - 12/03/2018
-                //Para homologação da Caixa é obrigatório ter as informações do SAC
-                if (Banco.Codigo == 104)
-                {
-                    //_instrucoesHtml = _instrucoesHtml +
-                    //                  "<br><br><p>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)</p> <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 </p><p> Ouvidoria: 0800 725 7474 - caixa.gov.br </p>";
-                    _instrucoesHtml = _instrucoesHtml +
-                                      "<br>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)<br/> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 Ouvidoria: 0800 725 7474 <br/> caixa.gov.br";
-                }
-		
+                MontaInstrucaoCaixa();
+
                 MontaInstrucoes(Boleto.Instrucoes);
 
                 if (Boleto.Cedente.Instrucoes.Count > 0)
@@ -440,6 +434,19 @@ namespace BoletoNet
             catch (Exception ex)
             {
                 throw new Exception("Erro na execução da transação.", ex);
+            }
+        }
+
+        private void MontaInstrucaoCaixa()
+        {
+            //Suelton - 12/03/2018
+            //Para homologação da Caixa é obrigatório ter as informações do SAC
+            if (Banco.Codigo == 104)
+            {
+                //_instrucoesHtml = _instrucoesHtml +
+                //                  "<br><br><p>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)</p> <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 </p><p> Ouvidoria: 0800 725 7474 - caixa.gov.br </p>";
+                _instrucoesHtml = _instrucoesHtml +
+                                  "<br>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)<br/> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 Ouvidoria: 0800 725 7474 <br/> caixa.gov.br";
             }
         }
 
@@ -480,9 +487,9 @@ namespace BoletoNet
                     //Adiciona a instrução as instruções disponíveis no Boleto
                     Instrucoes.Add(instrucao);
                 }
-		
-		 if (instrucoes.Any())
-		     _instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
+
+                if (instrucoes.Any())
+                    _instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
             }
         }
 
@@ -680,13 +687,13 @@ namespace BoletoNet
                     case (int)Bancos.Santander:
                         agenciaCodigoCedente = string.Format("{0}-{1}/{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Utils.FormatCode(Cedente.Codigo, 6));
                         if (string.IsNullOrEmpty(Cedente.ContaBancaria.DigitoAgencia))
-			{
-                            agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 6));			
-			    if (Utils.FormatCode(Cedente.Codigo, 6).Equals("000000"))
-			    {
-                               agenciaCodigoCedente = String.Format("{0}/{1}-{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.Conta,Cedente.ContaBancaria.DigitoConta);
-			    }
-		        }
+                        {
+                            agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 6));
+                            if (Utils.FormatCode(Cedente.Codigo, 6).Equals("000000"))
+                            {
+                                agenciaCodigoCedente = String.Format("{0}/{1}-{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.Conta, Cedente.ContaBancaria.DigitoConta);
+                            }
+                        }
                         break;
                     case (int)Bancos.HSBC:
                         agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 7)); //Solicitação do HSBC que mostrasse agencia/Conta - por Transis em 24/02/15
@@ -854,8 +861,6 @@ namespace BoletoNet
             if (imprimeFooter)
                 HtmlOfflineFooter(html);
 
-          
- 
             return html;
         }
 

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -481,7 +481,8 @@ namespace BoletoNet
                     Instrucoes.Add(instrucao);
                 }
 		
-		_instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
+		 if (instrucoes.Any())
+		     _instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
             }
         }
 


### PR DESCRIPTION
Instrução da caixa aparece mais de uma vez e dependendo do tamanho das instruções no formato do boleto carnê não iria aparecer a informação obrigatória. (Caixa é obrigatório ter as informações do SAC)